### PR TITLE
Enhance orbit animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ I'm bilingual (English/Spanish), a lifelong learner, and a fan of automating eve
 
 </details>
 
-<details>
+<details open>
 <summary>Orbiting Animation</summary>
 
 A playful SVG solar system built with pure SVG animations:

--- a/assets/orbit.svg
+++ b/assets/orbit.svg
@@ -1,33 +1,66 @@
-<svg width="200" height="200" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+<svg width="300" height="300" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="sunGradient" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="white" />
+      <stop offset="100%" stop-color="gold" />
+    </radialGradient>
+  </defs>
+
+  <!-- background stars -->
+  <g fill="white">
+    <circle cx="10" cy="10" r="0.4" />
+    <circle cx="20" cy="95" r="0.4" />
+    <circle cx="80" cy="40" r="0.4" />
+    <circle cx="100" cy="70" r="0.4" />
+    <circle cx="60" cy="15" r="0.4" />
+  </g>
+
   <!-- orbit paths -->
-  <circle cx="50" cy="50" r="35" fill="none" stroke="lightgray" stroke-width="0.5" stroke-dasharray="1,3" />
-  <circle cx="50" cy="50" r="25" fill="none" stroke="lightgray" stroke-width="0.5" stroke-dasharray="1,3" />
-  <circle cx="50" cy="50" r="15" fill="none" stroke="lightgray" stroke-width="0.5" stroke-dasharray="1,3" />
+  <circle cx="60" cy="60" r="55" fill="none" stroke="lightgray" stroke-width="0.5" stroke-dasharray="1,3" />
+  <circle cx="60" cy="60" r="45" fill="none" stroke="lightgray" stroke-width="0.5" stroke-dasharray="1,3" />
+  <circle cx="60" cy="60" r="35" fill="none" stroke="lightgray" stroke-width="0.5" stroke-dasharray="1,3" />
+  <circle cx="60" cy="60" r="25" fill="none" stroke="lightgray" stroke-width="0.5" stroke-dasharray="1,3" />
+  <circle cx="60" cy="60" r="15" fill="none" stroke="lightgray" stroke-width="0.5" stroke-dasharray="1,3" />
 
   <!-- central star -->
-  <circle cx="50" cy="50" r="3" fill="gold" />
+  <circle cx="60" cy="60" r="4" fill="url(#sunGradient)" />
 
   <!-- planets -->
   <g>
-    <circle cx="50" cy="15" r="2.5" fill="deepskyblue" />
+    <circle cx="60" cy="5" r="3" fill="deepskyblue" />
     <animateTransform attributeName="transform" attributeType="XML"
-                      type="rotate" from="0 50 50" to="360 50 50"
+                      type="rotate" from="0 60 60" to="360 60 60"
                       dur="8s" repeatCount="indefinite" />
   </g>
 
   <g>
-    <circle cx="50" cy="25" r="1.5" fill="limegreen">
-      <animate attributeName="r" values="1.5;2;1.5" dur="2s" repeatCount="indefinite" />
+    <circle cx="60" cy="15" r="2" fill="limegreen">
+      <animate attributeName="r" values="2;2.5;2" dur="2s" repeatCount="indefinite" />
     </circle>
     <animateTransform attributeName="transform" attributeType="XML"
-                      type="rotate" from="360 50 50" to="0 50 50"
+                      type="rotate" from="360 60 60" to="0 60 60"
                       dur="6s" repeatCount="indefinite" />
   </g>
 
   <g>
-    <circle cx="50" cy="35" r="2" fill="hotpink" />
+    <circle cx="60" cy="25" r="2.5" fill="hotpink" />
     <animateTransform attributeName="transform" attributeType="XML"
-                      type="rotate" from="0 50 50" to="360 50 50"
+                      type="rotate" from="0 60 60" to="360 60 60"
                       dur="12s" repeatCount="indefinite" />
+  </g>
+
+  <g>
+    <circle cx="60" cy="35" r="2.2" fill="orange" />
+    <ellipse cx="60" cy="35" rx="3.5" ry="1" fill="none" stroke="tan" stroke-width="0.5" />
+    <animateTransform attributeName="transform" attributeType="XML"
+                      type="rotate" from="0 60 60" to="360 60 60"
+                      dur="14s" repeatCount="indefinite" />
+  </g>
+
+  <g>
+    <circle cx="60" cy="45" r="3" fill="purple" />
+    <animateTransform attributeName="transform" attributeType="XML"
+                      type="rotate" from="360 60 60" to="0 60 60"
+                      dur="18s" repeatCount="indefinite" />
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- enlarge the animated SVG and add more effects
- keep the "Orbiting Animation" section expanded by default

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68448ddf8d5c8333be0b2fd1195b90aa