### PR TITLE
Enhance orbit animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Product-Minded Engineer - _**Building resilient code with strategic vision.**_
 A playful SVG solar system built with pure SVG animations:
 
 <p align="center">
-  <img src="assets/orbit.svg" alt="Animated solar orbit" style="width:100%;" />
+  <img src="assets/orbit.svg" alt="Animated solar orbit" style="width:80%;" />
 </p>
 
 </details>

--- a/assets/orbit.svg
+++ b/assets/orbit.svg
@@ -1,4 +1,4 @@
-<svg width="300" height="300" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+<svg width="250" height="250" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <radialGradient id="sunGradient" cx="50%" cy="50%" r="50%">
       <stop offset="0%" stop-color="white" />
@@ -8,75 +8,80 @@
 
   <!-- background stars -->
   <g fill="white">
-    <circle cx="10" cy="10" r="0.4" />
-    <circle cx="20" cy="95" r="0.4" />
-    <circle cx="80" cy="40" r="0.4" />
-    <circle cx="100" cy="70" r="0.4" />
-    <circle cx="60" cy="15" r="0.4" />
-    <!-- additional random stars -->
-    <circle cx="5" cy="85" r="0.4" />
-    <circle cx="30" cy="10" r="0.4" />
-    <circle cx="50" cy="50" r="0.4" />
-    <circle cx="70" cy="100" r="0.4" />
-    <circle cx="15" cy="30" r="0.4" />
-    <circle cx="110" cy="20" r="0.4" />
-    <circle cx="90" cy="90" r="0.4" />
-    <circle cx="40" cy="75" r="0.4" />
-    <circle cx="75" cy="60" r="0.4" />
-    <circle cx="95" cy="50" r="0.4" />
-    <circle cx="30" cy="90" r="0.4" />
-    <circle cx="60" cy="100" r="0.4" />
-    <circle cx="45" cy="20" r="0.4" />
-    <circle cx="25" cy="55" r="0.4" />
+    <circle cx="5" cy="5" r="0.4" />
+    <circle cx="15" cy="20" r="0.4" />
+    <circle cx="25" cy="80" r="0.4" />
+    <circle cx="35" cy="60" r="0.4" />
+    <circle cx="45" cy="10" r="0.4" />
+    <circle cx="55" cy="90" r="0.4" />
+    <circle cx="65" cy="30" r="0.4" />
+    <circle cx="75" cy="50" r="0.4" />
     <circle cx="85" cy="15" r="0.4" />
+    <circle cx="95" cy="70" r="0.4" />
+    <circle cx="105" cy="40" r="0.4" />
+    <circle cx="115" cy="95" r="0.4" />
+    <!-- additional random stars to fill space -->
+    <circle cx="10" cy="100" r="0.4" />
+    <circle cx="20" cy="45" r="0.4" />
+    <circle cx="30" cy="25" r="0.4" />
+    <circle cx="40" cy="85" r="0.4" />
+    <circle cx="50" cy="55" r="0.4" />
+    <circle cx="60" cy="15" r="0.4" />
+    <circle cx="70" cy="95" r="0.4" />
+    <circle cx="80" cy="35" r="0.4" />
+    <circle cx="90" cy="5" r="0.4" />
+    <circle cx="100" cy="85" r="0.4" />
+    <circle cx="110" cy="25" r="0.4" />
+    <circle cx="15" cy="60" r="0.4" />
+    <circle cx="25" cy="110" r="0.4" />
+    <circle cx="35" cy="40" r="0.4" />
+    <circle cx="45" cy="105" r="0.4" />
+    <circle cx="55" cy="35" r="0.4" />
+    <circle cx="65" cy="75" r="0.4" />
+    <circle cx="75" cy="20" r="0.4" />
+    <circle cx="85" cy="100" r="0.4" />
+    <circle cx="95" cy="55" r="0.4" />
+    <circle cx="105" cy="10" r="0.4" />
   </g>
 
-  <!-- orbit paths -->
-  <circle cx="60" cy="60" r="55" fill="none" stroke="lightgray" stroke-width="0.5" stroke-dasharray="1,3" />
-  <circle cx="60" cy="60" r="45" fill="none" stroke="lightgray" stroke-width="0.5" stroke-dasharray="1,3" />
-  <circle cx="60" cy="60" r="35" fill="none" stroke="lightgray" stroke-width="0.5" stroke-dasharray="1,3" />
-  <circle cx="60" cy="60" r="25" fill="none" stroke="lightgray" stroke-width="0.5" stroke-dasharray="1,3" />
-  <circle cx="60" cy="60" r="15" fill="none" stroke="lightgray" stroke-width="0.5" stroke-dasharray="1,3" />
-
   <!-- central star -->
-  <circle cx="60" cy="60" r="4" fill="url(#sunGradient)" />
+  <circle cx="60" cy="60" r="6" fill="url(#sunGradient)" />
 
   <!-- planets -->
   <g>
-    <circle cx="60" cy="5" r="3" fill="deepskyblue" />
-    <animateTransform attributeName="transform" attributeType="XML"
-                      type="rotate" from="0 60 60" to="360 60 60"
-                      dur="8s" repeatCount="indefinite" />
+    <circle cx="60" cy="5" r="1" fill="gray" />
+    <animateTransform attributeName="transform" attributeType="XML" type="rotate" from="0 60 60" to="360 60 60" dur="8s" repeatCount="indefinite" />
+  </g>
+  <g>
+    <circle cx="60" cy="15" r="2" fill="tan" />
+    <animateTransform attributeName="transform" attributeType="XML" type="rotate" from="360 60 60" to="0 60 60" dur="12s" repeatCount="indefinite" />
+  </g>
+  <g>
+    <circle cx="60" cy="25" r="2.2" fill="deepskyblue" />
+    <animateTransform attributeName="transform" attributeType="XML" type="rotate" from="0 60 60" to="360 60 60" dur="16s" repeatCount="indefinite" />
+  </g>
+  <g>
+    <circle cx="60" cy="35" r="1.8" fill="orange" />
+    <animateTransform attributeName="transform" attributeType="XML" type="rotate" from="0 60 60" to="360 60 60" dur="20s" repeatCount="indefinite" />
+  </g>
+  <g>
+    <circle cx="60" cy="45" r="4" fill="peru" />
+    <animateTransform attributeName="transform" attributeType="XML" type="rotate" from="360 60 60" to="0 60 60" dur="30s" repeatCount="indefinite" />
   </g>
 
-  <g>
-    <circle cx="60" cy="15" r="2" fill="limegreen">
-      <animate attributeName="r" values="2;2.5;2" dur="2s" repeatCount="indefinite" />
-    </circle>
-    <animateTransform attributeName="transform" attributeType="XML"
-                      type="rotate" from="360 60 60" to="0 60 60"
-                      dur="6s" repeatCount="indefinite" />
+  <!-- shooting star appears first and every minute -->
+  <g opacity="0">
+    <line x1="0" y1="0" x2="4" y2="1" stroke="white" stroke-width="0.5" />
+    <circle cx="4" cy="1" r="0.7" fill="white" />
+    <animate attributeName="opacity" values="1;0" dur="2s" begin="0s;60s" repeatCount="indefinite" />
+    <animateTransform attributeName="transform" type="translate" from="-20 -10" to="140 130" dur="2s" begin="0s;60s" repeatCount="indefinite" />
   </g>
 
-  <g>
-    <circle cx="60" cy="25" r="2.5" fill="hotpink" />
-    <animateTransform attributeName="transform" attributeType="XML"
-                      type="rotate" from="0 60 60" to="360 60 60"
-                      dur="12s" repeatCount="indefinite" />
-  </g>
-
-  <g>
-    <circle cx="60" cy="35" r="2.2" fill="orange" />
-    <ellipse cx="60" cy="35" rx="3.5" ry="1" fill="none" stroke="tan" stroke-width="0.5" />
-    <animateTransform attributeName="transform" attributeType="XML"
-                      type="rotate" from="0 60 60" to="360 60 60"
-                      dur="14s" repeatCount="indefinite" />
-  </g>
-
-  <g>
-    <circle cx="60" cy="45" r="3" fill="purple" />
-    <animateTransform attributeName="transform" attributeType="XML"
-                      type="rotate" from="360 60 60" to="0 60 60"
-                      dur="18s" repeatCount="indefinite" />
+  <!-- rocket appears after 20s and then every minute offset -->
+  <g opacity="0">
+    <polygon points="0,0 2,1 0,2" fill="silver" />
+    <rect x="-0.3" y="0.8" width="0.6" height="0.6" fill="orange" />
+    <animate attributeName="opacity" values="1;0" dur="3s" begin="20s;80s" repeatCount="indefinite" />
+    <animateTransform attributeName="transform" type="translate" from="140 120" to="-20 -10" dur="3s" begin="20s;80s" repeatCount="indefinite" />
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- tweak README to display animation at 80% width
- update SVG with more stars and larger sun
- vary planet sizes and remove orbit guide lines
- add a sporadic shooting star and rocket animation

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68449118c8c0833390e92fc53379426d