### PR TITLE
docs: prevent package managers

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,0 +1,9 @@
+# Repository Memory
+
+This log of lessons and principles guides work on this portfolio.
+
+- Documentation is treated like code and versioned accordingly.
+- Automate tasks with simple scripts without relying on package managers. npm, pip, and similar tools are off limits.
+- Prefer strict TypeScript and immutable patterns when code is involved.
+- Keep commits atomic and follow Conventional Commits.
+- Practice Test-Driven Development for any substantial features.

--- a/README.md
+++ b/README.md
@@ -61,4 +61,11 @@ I'm bilingual (English/Spanish), a lifelong learner, and a fan of automating eve
 
 </details>
 
+<details>
+<summary>Repository Scripts</summary>
+
+Run `./scripts/check-links.sh` to verify that all links in the README are reachable. The script uses only `bash` and `curl` and avoids any package managers.
+
+</details>
+
 Cheers!

--- a/RULES.md
+++ b/RULES.md
@@ -10,17 +10,13 @@ These rules keep development consistent across the project. The document is inte
 
 ## Local Workflow
 
-Use these npm scripts during feature work:
+All automation must rely only on the tools committed in this repository or those already available on the system. **Do not use npm or any other package manager.**
 
-- `npm ci` – install dependencies
-- `npm start` – run the Metro bundler
-- `npm run ios` – run the iOS app
-- `npm run android` – run the Android app
-- `npm test` – run the full test suite
-- `npm run typecheck` – run TypeScript checks
-- `npm run build` – build release artifacts with Fastlane
+Use the helper scripts under `scripts/` during feature work:
 
-Run `npm ci`, `npm test`, `npm run typecheck`, and `npm run build` before pushing changes. CI uses the same commands.
+- `scripts/check-links.sh` – ensure documentation links are valid
+
+Run the provided scripts and any tests before pushing changes. CI mirrors these commands.
 
 ## Commit Standards
 
@@ -48,6 +44,6 @@ After merging into `develop`, automatically open a PR that merges `develop` into
 
 ## Continuous Integration
 
-All dependencies must be installed with `npm ci` in CI jobs. The Super-Linter runs on every pull request via `.github/workflows/super-linter.yml`.
+CI jobs use the same helper scripts and do **not** install dependencies with package managers. The Super-Linter runs on every pull request via `.github/workflows/super-linter.yml`.
 
 Find ways to mitigate any current Super-Linter failures as we continue to make incremental changes. However, failures should not mean we break existing functionality and the way the UI looks today. Take a balanced approach here.

--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Simple link checker for README.md. Avoids external dependencies.
+set -euo pipefail
+
+file="README.md"
+
+if [ ! -f "$file" ]; then
+  echo "README.md not found" >&2
+  exit 1
+fi
+
+links=$(grep -oE 'https?://[^)]+' "$file" | sort -u)
+
+fail=0
+for url in $links; do
+  if curl -Is "$url" >/dev/null 2>&1; then
+    echo "OK: $url"
+  else
+    echo "BROKEN: $url" >&2
+    fail=1
+  fi
+done
+
+exit $fail


### PR DESCRIPTION
## Summary
- restructure RULES.md to avoid npm and point to `scripts/check-links.sh`
- add an initial MEMORY.md with core principles
- add a simple link checker script
- document the script in the README

## Testing
- `scripts/check-links.sh`

------
https://chatgpt.com/codex/tasks/task_e_68600fc69678833393a9e2a10412b7c5