### PR TITLE
Feature: add markdown validation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ I'm bilingual (English/Spanish), a lifelong learner, and a fan of automating eve
 
 Run `./scripts/check-links.sh` to verify that all links in the README are reachable. The script uses only `bash` and `curl` and avoids any package managers.
 Run `./scripts/check-trailing-whitespace.sh README.md` to ensure Markdown files don't contain trailing spaces. This keeps diffs clean and prevents lint errors.
+Run `./scripts/check-markdown.sh` to run link and whitespace checks on all Markdown files.
 
 </details>
 

--- a/RULES.md
+++ b/RULES.md
@@ -15,6 +15,7 @@ All automation must rely only on the tools committed in this repository or those
 Use the helper scripts under `scripts/` during feature work:
 
 - `scripts/check-links.sh` – ensure documentation links are valid
+- `scripts/check-markdown.sh` – run all checks on repository Markdown files
 
 Run the provided scripts and any tests before pushing changes. CI mirrors these commands.
 

--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -1,24 +1,28 @@
 #!/usr/bin/env bash
-# Simple link checker for README.md. Avoids external dependencies.
+# Simple link checker for markdown files. Avoids external dependencies.
 set -euo pipefail
 
-file="README.md"
-
-if [ ! -f "$file" ]; then
-  echo "README.md not found" >&2
-  exit 1
+files=("$@")
+if [ ${#files[@]} -eq 0 ]; then
+  files=(README.md)
 fi
 
-links=$(grep -oE 'https?://[^)]+' "$file" | sort -u)
-
 fail=0
-for url in $links; do
-  if curl -Is "$url" >/dev/null 2>&1; then
-    echo "OK: $url"
-  else
-    echo "BROKEN: $url" >&2
+for file in "${files[@]}"; do
+  if [ ! -f "$file" ]; then
+    echo "Missing file: $file" >&2
     fail=1
+    continue
   fi
+  links=$(grep -oE 'https?://[^)]+' "$file" | sort -u)
+  for url in $links; do
+    if curl -Is "$url" >/dev/null 2>&1; then
+      echo "OK: $url"
+    else
+      echo "BROKEN: $url" >&2
+      fail=1
+    fi
+  done
+  echo
 done
-
 exit $fail

--- a/scripts/check-markdown.sh
+++ b/scripts/check-markdown.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Run basic checks on all markdown files.
+set -euo pipefail
+
+files=$(find . -name '*.md' | sort)
+
+fail=0
+for file in $files; do
+  echo "Checking $file"
+  ./scripts/check-trailing-whitespace.sh "$file" || fail=1
+  ./scripts/check-links.sh "$file" || fail=1
+  echo
+done
+exit $fail


### PR DESCRIPTION
## Summary
- enhance `check-links.sh` to accept optional files
- add `check-markdown.sh` to run link and whitespace checks across all markdown files
- document new script usage in README and RULES

## Codex CI
- `scripts/check-markdown.sh` executed (link checks fail for blocked domains)
- `scripts/check-trailing-whitespace.sh` executed with no issues


------
https://chatgpt.com/codex/tasks/task_e_68602bf88efc83339a56b9f6e9fccdd7